### PR TITLE
Feature: Initial SQLite DB Integration for Patient Profile persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,2 @@
-# caremap-custom-template
-Template project to Get Started
-- This is the template file to get started for any caremap project.
-
-### List of dependencies added :
-- Expo React Native Navigation TypeScript template
-- Gluestack-UI
+# caremap
+- Caremap is a patient and family oriented application which allows for the secure storage and sharing of important medical information, often not found or easily accessible to families.

--- a/app.json
+++ b/app.json
@@ -4,12 +4,12 @@
     "slug": "caremap",
     "version": "1.0.0",
     "orientation": "portrait",
-    "icon": "./assets/images/icon.png",
+    "icon": "./assets/careMap-logo.png",
     "scheme": "caremapcustomtemplate",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "splash": {
-      "image": "./assets/images/splash-icon.png",
+      "image": "./assets/careMap-logo.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,18 +1,30 @@
 import { GluestackUIProvider } from "@/components/ui/gluestack-ui-provider";
 import "@/global.css";
+import { useDatabase } from "@/services/database/db";
+import { SQLITE_DB_NAME } from "@/utils/config";
 import { Stack } from "expo-router";
+import { SQLiteProvider } from "expo-sqlite";
 import React from "react";
 
 const RootLayout = () => {
   return (
-    <GluestackUIProvider mode="light">
-      <Stack
-        screenOptions={{
-          headerShown: false,
-          headerBackVisible: false,
-        }}
-      />
-    </GluestackUIProvider>
+    <SQLiteProvider
+      databaseName={SQLITE_DB_NAME}
+      onInit={async (db) => {
+        const { runMigrations } = useDatabase(db);
+        await runMigrations();
+        console.log(`Migration completed.`);
+      }}
+    >
+      <GluestackUIProvider mode="light">
+        <Stack
+          screenOptions={{
+            headerShown: false,
+            headerBackVisible: false,
+          }}
+        />
+      </GluestackUIProvider>
+    </SQLiteProvider>
   );
 };
 

--- a/app/myhealth/home.tsx
+++ b/app/myhealth/home.tsx
@@ -5,15 +5,76 @@ import {
   initializeSession,
   signOut,
 } from "@/services/auth-service/google-auth";
-import { User } from "@/services/database/migrations/v1/schema_v1";
+import { Patient, User } from "@/services/database/migrations/v1/schema_v1";
+import { useSQLiteContext } from "expo-sqlite";
+import { UserModel } from "@/services/database/models/UserModel";
+import { PatientModel } from "@/services/database/models/PatientModel";
 
 const Home = () => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const [patient, setPatient] = useState<Patient | null>(null);
+
+  const db = useSQLiteContext();
+  const userModel = new UserModel(db);
+  const patientModel = new PatientModel(db);
 
   useEffect(() => {
+    console.log(`DB Path : "${db.databasePath}"`);
     initializeSession(setUser).finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    if (user) {
+      handleUserInsert(user);
+    }
+  }, [user]);
+
+  const handleUserInsert = async (currentUser: User) => {
+    const existingUser = await userModel.getUser(currentUser.email);
+
+    try {
+      if (!existingUser) {
+        await userModel.insert({
+          id: user?.id,
+          name: user?.name,
+          email: user?.email,
+        });
+
+        const allUsers = await userModel.getAll();
+        console.log("User: ", allUsers);
+      }
+    } catch (err) {
+      console.log("Error: ", err);
+    }
+  };
+
+  const handlePatientData = async () => {
+    console.log(user?.id);
+    let patientData;
+    try {
+      if (user?.id) {
+        patientData = await patientModel.getPatientByUserId(user.id);
+        console.log("Patient: ", patientData);
+
+        if (patientData) {
+          console.log("Patient found...");
+          setPatient(patientData);
+        } else {
+          console.log("Patient not found. Inserting...");
+          await patientModel.insert({
+            user_id: user?.id,
+            name: `${user?.name}`,
+          });
+          const patientData = await patientModel.getPatientByUserId(user.id);
+          console.log("Patient: ", patientData);
+          setPatient(patientData);
+        }
+      }
+    } catch (err) {
+      console.log("Error: ", err);
+    }
+  };
 
   const handleSignOut = async () => {
     await signOut();
@@ -36,6 +97,10 @@ const Home = () => {
       />
       <Text>Name: {user.name}</Text>
       <Text>Email: {user.email}</Text>
+      <Text>Patient name: {patient?.name}</Text>
+
+      <Button title="Get Patient Data" onPress={handlePatientData} />
+
       <Button title="Sign Out" onPress={handleSignOut} />
     </View>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,12 +22,14 @@
         "babel-plugin-module-resolver": "^5.0.2",
         "expo": "~53.0.7",
         "expo-auth-session": "~6.1.5",
+        "expo-file-system": "~18.1.10",
         "expo-font": "~13.3.1",
         "expo-linear-gradient": "~14.1.4",
         "expo-linking": "~7.1.4",
         "expo-router": "~5.0.5",
         "expo-secure-store": "~14.2.3",
         "expo-splash-screen": "~0.30.8",
+        "expo-sqlite": "~15.2.10",
         "expo-status-bar": "~2.2.3",
         "expo-system-ui": "~5.0.7",
         "expo-web-browser": "~14.1.6",
@@ -4369,6 +4371,12 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
+    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -4727,9 +4735,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
+      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4746,8 +4754,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001716",
-        "electron-to-chromium": "^1.5.149",
+        "caniuse-lite": "^1.0.30001718",
+        "electron-to-chromium": "^1.5.160",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -4915,9 +4923,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001720",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
+      "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
       "funding": [
         {
           "type": "opencollective",
@@ -5890,9 +5898,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.159",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.159.tgz",
-      "integrity": "sha512-CEvHptWAMV5p6GJ0Lq8aheyvVbfzVrv5mmidu1D3pidoVNkB3tTBsTMVtPJ+rzRK5oV229mCLz9Zj/hNvU8GBA==",
+      "version": "1.5.161",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.161.tgz",
+      "integrity": "sha512-hwtetwfKNZo/UlwHIVBlKZVdy7o8bIZxxKs0Mv/ROPiQQQmDgdm5a+KvKtBsxM8ZjFzTaCeLoodZ8jiBE3o9rA==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -6468,6 +6476,20 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-sqlite": {
+      "version": "15.2.10",
+      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-15.2.10.tgz",
+      "integrity": "sha512-F7IYvXSOh3vIqhRkmaUvIP595Oqh8888CV5wpys94/437LkMYAOzMnqoscr+TCCmcO9XWURsMbBGsCVPHanlYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "await-lock": "^2.2.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "react-native-svg": "^15.2.0",
     "react-native-web": "~0.20.0",
     "tailwindcss": "^3.4.17",
-    "expo-auth-session": "~6.1.5"
+    "expo-auth-session": "~6.1.5",
+    "expo-sqlite": "~15.2.10",
+    "expo-file-system": "~18.1.10"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/services/database/BaseModel.ts
+++ b/services/database/BaseModel.ts
@@ -1,0 +1,100 @@
+import { SQLiteDatabase } from 'expo-sqlite';
+
+export abstract class BaseModel<T> {
+
+    protected db: SQLiteDatabase;
+    protected tableName: string;
+
+    constructor(db: SQLiteDatabase, tableName: string) {
+        this.db = db;
+        this.tableName = tableName;
+    }
+
+    // Wrapper method to run any SQL query safely inside a transaction using prepared statements
+    protected async run(sql: string, params: any[] = []) {
+        console.log("SQL: ", sql);
+        console.log("Params: ", params);
+        let result: any;
+        await this.db.withTransactionAsync(async () => {
+            const stmt = await this.db.prepareAsync(sql);
+            try {
+                result = await stmt.executeAsync(...params); // store the result
+            } finally {
+                await stmt.finalizeAsync(); // always finalize the statement
+            }
+        });
+
+        return result;
+    }
+
+    async getAll(): Promise<T[]> {
+        const sql = `SELECT * FROM ${this.tableName};`;
+        console.log("SQL: ", sql);
+        const result = await this.db.getAllAsync<T>(sql);
+        console.log("Result: ", result.toString());
+        return result;
+    }
+
+    async getByFields(fields: Partial<T>): Promise<T[]> {
+        const keys = Object.keys(fields);
+        const values = Object.values(fields);
+        if (keys.length === 0) return [];
+        const conditions = keys.map((key) => `${key} = ?`).join(' AND ');
+        const sql = `SELECT * FROM ${this.tableName} WHERE ${conditions}`;
+        const result = await this.run(sql, values);
+        return result;
+    }
+
+    async insert(data: Partial<T>): Promise<void> {
+        const keys = Object.keys(data);
+        const values = Object.values(data);
+        const placeholders = keys.map(() => '?').join(',');
+        console.log(`Data: `, data);
+
+        const sql = `INSERT INTO ${this.tableName} (${keys.join(',')}) VALUES (${placeholders})`;
+        await this.run(sql, values);
+    }
+
+    async insertAll(data: Partial<T>[]): Promise<void> {
+        if (data.length === 0) return;
+
+        const keys = Object.keys(data[0]);
+        const placeholders = `(${keys.map(() => '?').join(',')})`;
+        const allPlaceholders = data.map(() => placeholders).join(', ');
+        const values = data.flatMap(row => keys.map(key => row[key as keyof T]));
+
+        const sql = `INSERT INTO ${this.tableName} (${keys.join(',')}) VALUES ${allPlaceholders};`;
+        await this.run(sql, values);
+    }
+
+    async updateByFields(
+        data: Partial<T>,         // fields to update
+        conditions: Partial<T>    // where clause conditions
+    ): Promise<void> {
+        const setKeys = Object.keys(data);
+        const setValues = Object.values(data);
+        const setClause = setKeys.map(key => `${key} = ?`).join(', ');
+
+        const whereKeys = Object.keys(conditions);
+        const whereValues = Object.values(conditions);
+        const whereClause = whereKeys.map(key => `${key} = ?`).join(' AND ');
+
+        const sql = `UPDATE ${this.tableName} SET ${setClause} WHERE ${whereClause}`;
+        const values = [...setValues, ...whereValues];
+
+        await this.run(sql, values);
+    }
+
+    async deleteByFields(where: Partial<T>): Promise<void> {
+        const keys = Object.keys(where);
+        const values = Object.values(where);
+
+        if (keys.length === 0) return;
+
+        const whereClause = keys.map((key) => `${key} = ?`).join(' AND ');
+        const sql = `DELETE FROM ${this.tableName} WHERE ${whereClause}`;
+
+        await this.run(sql, values);
+    }
+
+}

--- a/services/database/db.ts
+++ b/services/database/db.ts
@@ -1,0 +1,29 @@
+import { SQLITE_DB_NAME } from "@/utils/config";
+import { SQLiteDatabase } from "expo-sqlite";
+import * as v1 from './migrations/v1/migration_v1';
+
+export const DB_NAME = SQLITE_DB_NAME;
+export const DB_VERSION = 1;
+
+export const useDatabase = (db: SQLiteDatabase) => {
+
+    const runMigrations = async () => {
+        const result = await db.getAllAsync<{ user_version: number }>(
+            `PRAGMA user_version;`
+        );
+        const currentVersion = result[0]?.user_version ?? 0;
+
+        console.log("DB version: ", currentVersion);
+
+        if (currentVersion < DB_VERSION) {
+            await db.withTransactionAsync(async () => {
+                if (currentVersion < 1) {
+                    await v1.up(db);
+                }
+                await db.execAsync(`PRAGMA user_version = ${DB_VERSION}`);
+            });
+        }
+    };
+
+    return { db, runMigrations };
+};

--- a/services/database/migrations/v1/migration_v1.ts
+++ b/services/database/migrations/v1/migration_v1.ts
@@ -1,0 +1,26 @@
+import { SQLiteDatabase } from "expo-sqlite";
+
+export const up = async (db: SQLiteDatabase) => {
+  await db.execAsync(`
+    CREATE TABLE IF NOT EXISTS users (
+      id TEXT PRIMARY KEY,
+      email TEXT NOT NULL UNIQUE,
+      name TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS patients (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL,
+      age INTEGER,
+      relationship TEXT,
+      weight REAL,
+      height REAL,
+      gender TEXT,
+      birthdate TEXT,
+      FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+    );
+  `);
+
+  console.log(`Tables created.`);
+};

--- a/services/database/migrations/v1/schema_v1.ts
+++ b/services/database/migrations/v1/schema_v1.ts
@@ -16,3 +16,8 @@ export interface Patient {
   gender?: string;
   birthdate?: string;
 }
+
+export const tables = {
+  USER: 'users',
+  PATIENT: 'patients',
+}

--- a/services/database/models/PatientModel.ts
+++ b/services/database/models/PatientModel.ts
@@ -1,0 +1,17 @@
+import { SQLiteDatabase } from "expo-sqlite";
+import { BaseModel } from "../BaseModel";
+import { Patient, tables } from "../migrations/v1/schema_v1";
+
+export class PatientModel extends BaseModel<Patient> {
+
+  constructor(db: SQLiteDatabase) {
+    super(db, `${tables.PATIENT}`);
+  }
+
+  async getPatientByUserId(userId: string): Promise<Patient | null> {
+    const result = await this.db.getFirstAsync<Patient>(`SELECT * FROM ${tables.PATIENT} WHERE user_id = ?`, [userId]);
+    console.log(result);
+    return result;
+  }
+
+}

--- a/services/database/models/UserModel.ts
+++ b/services/database/models/UserModel.ts
@@ -1,0 +1,17 @@
+import { SQLiteDatabase } from "expo-sqlite";
+import { BaseModel } from "../BaseModel";
+import { User, tables } from "../migrations/v1/schema_v1";
+
+export class UserModel extends BaseModel<User> {
+
+  constructor(db: SQLiteDatabase) {
+    super(db, `${tables.USER}`);
+  }
+
+  async getUser(email: string): Promise<User | null> {
+    const result = await this.db.getFirstAsync<User>(`SELECT * FROM ${tables.USER} WHERE email = ?`, [email]);
+    console.log(result);
+    return result;
+  }
+
+}


### PR DESCRIPTION
### Overview
- This PR introduces the initial integration of **SQLite** as a local data storage solution for the app. It enables storing and retrieving a basic **user-linked patient profile**, laying the foundation for persistent offline functionality.

---
### What’s Included
- **SQLite** integration, abstracted behind a modular layer to allow future scalability for local device storage.
- Data schema is versioned for migration support. 
   Initial schema & migration has been setup for patient profile data.
- Stores patient profile after SSO login via logic in `/myhealth/home.tsx`.
- **Demo feature:** “Get Patient Data” button added in `home` screen:
  - Inserts a sample patient (name) linked to the currently signed-in user.
  - Retrieves and displays the saved data for testing/demo purposes.
  
---
### Flow Summary
1. User completes SSO and lands on the `home` screen.
2. Patient profile is saved locally if it doesn’t exist already.
3. On tapping the “Get Patient Data” button:
   - Inserts a sample patient record tied to the current user ID.
   - Retrieves and displays patient data.

---
### Notes
- Home Screen to be replaced in the upcoming sprint
- Tested on iOS Simulator